### PR TITLE
drop python3.6 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
     rev: v2.6.0
     hooks:
     -   id: reorder-python-imports
-        args: [--py3-plus]
+        args: [--py37-plus, --add-import, 'from __future__ import annotations']
 -   repo: https://github.com/asottile/add-trailing-comma
     rev: v2.2.1
     hooks:
@@ -32,7 +32,7 @@ repos:
     rev: v2.31.0
     hooks:
     -   id: pyupgrade
-        args: [--py36-plus]
+        args: [--py37-plus]
 -   repo: https://github.com/asottile/setup-cfg-fmt
     rev: v1.20.0
     hooks:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,10 +10,10 @@ resources:
       type: github
       endpoint: github
       name: asottile/azure-pipeline-templates
-      ref: refs/tags/v2.1.0
+      ref: refs/tags/v2.4.0
 
 jobs:
 - template: job--python-tox.yml@asottile
   parameters:
-    toxenvs: [pypy3, py36, py37]
+    toxenvs: [py37, py38, py39, py310]
     os: linux

--- a/re_assert.py
+++ b/re_assert.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from typing import Any
-from typing import Optional
 from typing import Pattern
 
 import regex
@@ -8,7 +9,7 @@ import regex
 class Matches:  # TODO: Generic[AnyStr] (binary pattern support)
     def __init__(self, pattern: str, *args: Any, **kwargs: Any) -> None:
         self._pattern = regex.compile(pattern, *args, **kwargs)
-        self._fail: Optional[str] = None
+        self._fail: str | None = None
         self._type = type(pattern)
 
     def _fail_message(self, fail: str) -> str:
@@ -63,5 +64,5 @@ class Matches:  # TODO: Generic[AnyStr] (binary pattern support)
         assert self == s, self._fail
 
     @classmethod
-    def from_pattern(cls, pattern: Pattern[str]) -> 'Matches':
+    def from_pattern(cls, pattern: Pattern[str]) -> Matches:
         return cls(pattern.pattern, pattern.flags)

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,6 @@ classifiers =
     License :: OSI Approved :: MIT License
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -25,7 +24,7 @@ classifiers =
 py_modules = re_assert
 install_requires =
     regex
-python_requires = >=3.6.1
+python_requires = >=3.7
 
 [bdist_wheel]
 universal = True

--- a/setup.py
+++ b/setup.py
@@ -1,2 +1,4 @@
+from __future__ import annotations
+
 from setuptools import setup
 setup()

--- a/tests/re_assert_test.py
+++ b/tests/re_assert_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 
 import pytest

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,pypy3,pre-commit
+envlist = py37,pypy3,pre-commit
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
python 3.6 reached end of life on 2021-12-23

Committed via https://github.com/asottile/all-repos