### PR TITLE
Support fallback to the built-in `re` module, for PyPy3

### DIFF
--- a/re_assert.py
+++ b/re_assert.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 from typing import Any
 from typing import Pattern
 
-import regex
+try:
+    import regex
+except ImportError:
+    import re as regex
 
 
 class Matches:  # TODO: Generic[AnyStr] (binary pattern support)


### PR DESCRIPTION
Add a fallback to the built-in `re` module if `regex` is not available. This is needed for proper PyPy3 support, since the `regex` package does not support PyPy correctly.  In particular, it doesn't handle non-ASCII characters correctly, it does not compile with GCC 14 and upstream indicated plans to block installing it on PyPy completely.

For more details, see:
https://github.com/mrabarnett/mrab-regex?tab=readme-ov-file#pypy https://github.com/mrabarnett/mrab-regex/issues/521#issuecomment-1936260187